### PR TITLE
Replace spaces with tab in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ gen:
 .PHONY: lint
 lint:
 ifdef CI
-        gex reviewdog -reporter=github-pr-review
+	gex reviewdog -reporter=github-pr-review
 else
-        gex reviewdog -diff="git diff master"
+	gex reviewdog -diff="git diff master"
 endif
 
 .PHONY: test


### PR DESCRIPTION
## WHY

`make` stops with the following error:
```bash
$ make
Makefile:80: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.
```

## WHAT

- Replace spaces with tabs in `Makefile`